### PR TITLE
made bandwidth panel not showing if no ports enabled

### DIFF
--- a/app/hardware/server/view/manage/panel/panel.bandwidth.pug
+++ b/app/hardware/server/view/manage/panel/panel.bandwidth.pug
@@ -1,4 +1,5 @@
 server-bandwidth-panel(
+  ng-if="server.switch"
   server="server"
   filter="filter"
 )


### PR DESCRIPTION
Closes https://github.com/synergycp/scp-theme-admin/issues/672

I've made it not showing if `server.switch` field is falsy. But don't know if server can have a switch without port being assigned to it?