### PR TITLE
CLients: Add param to get vip clients BMD-111

### DIFF
--- a/app/user/client/list/filters/filters.pug
+++ b/app/user/client/list/filters/filters.pug
@@ -10,3 +10,7 @@ include /resources/angle/pug/mixins/form
           placeholder="{{ 'client.list.filter.search.PLACEHOLDER' | translate }}"
           observable-focus="filters.searchFocus"
         )
+      +label("{{ 'client.list.filter.showVip.LABEL' | translate }}")
+        .checkbox
+          label
+            input(type="checkbox" ng-model="filters.current['billing_ignore_auto_suspend']" ng-change="filters.fireChangeEvent()")

--- a/resources/assets/lang/en/client.json
+++ b/resources/assets/lang/en/client.json
@@ -36,6 +36,9 @@
       "search": {
         "LABEL": "Search",
         "PLACEHOLDER": "Type to search..."
+      },
+      "showVip": {
+        "LABEL": "Show Vip clients"
       }
     }
   },


### PR DESCRIPTION
To implement this new feature, I need to create a checkbox that enables the ability to display only VIP clients. The backend will receive this new parameter and incorporate it into the query.

All clientes.
![all_clients](https://github.com/synergycp/scp-theme-admin/assets/12122895/2bc21da8-ffb5-4dcc-9e1a-d4d8e76bbb69)

Only vip clients.
![only_vip_clients](https://github.com/synergycp/scp-theme-admin/assets/12122895/8dcdb807-482d-49a2-b11e-c71b0882fca3)
