### PR TITLE
Feature BA-661 switch port add and delete manually

### DIFF
--- a/app/network/switch/port/port.component.js
+++ b/app/network/switch/port/port.component.js
@@ -24,8 +24,6 @@
 
     ports.$onInit = init;
 
-
-
     ports.createPort = openCreatePortModal;
     //////////
 

--- a/app/network/switch/port/port.component.js
+++ b/app/network/switch/port/port.component.js
@@ -19,19 +19,35 @@
   /**
    * @ngInject
    */
-  function SwitchPortListCtrl(List, ListFilter, $scope) {
+  function SwitchPortListCtrl(List, ListFilter, $scope, PortModal, PortBulk) {
     var ports = this;
 
     ports.$onInit = init;
 
+
+
+    ports.createPort = openCreatePortModal;
     //////////
+
+    function openCreatePortModal() {
+      PortModal.create(ports.switch.id)
+        .open()
+        .result
+        .then(function (port) {
+          ports.list.refresh.now();
+        })
+        .catch(function () {
+        });
+
+
+    };
 
     function init() {
       ports.list = List('switch/'+ports.switch.id+'/port')
         .setPaginationAndSortToUrl();
       ports.list.load();
       ports.filters = ListFilter(ports.list);
-
+      PortBulk(ports.list);
       $scope.$on('$destroy', onDestroy);
     }
 

--- a/app/network/switch/port/port.factory.js
+++ b/app/network/switch/port/port.factory.js
@@ -1,0 +1,22 @@
+(function () {
+  'use strict';
+
+  angular
+    .module('app.network.switch.port')
+    .factory('PortBulk', PortBulkFactory);
+
+  /**
+   * PortBulk Factory
+   *
+   * @ngInject
+   */
+  function PortBulkFactory(ListConfirm) {
+    return function (list) {
+      var confirm = ListConfirm(list, 'switch.port.list.modal.delete');
+
+      list.bulk.add('Delete', confirm.delete);
+
+      return list;
+    };
+  }
+})();

--- a/app/network/switch/port/port.form.component.js
+++ b/app/network/switch/port/port.form.component.js
@@ -1,0 +1,58 @@
+(function () {
+  'use strict';
+
+  var INPUTS = {
+    name: '',
+    hubId: null
+  };
+
+  angular
+    .module('app.network.switch.port')
+    .component('portForm', {
+      require: {
+      },
+      bindings: {
+        form: '=',
+      },
+      controller: 'PortFormCtrl as portForm',
+      transclude: true,
+      templateUrl: 'app/network/switch/port/port.form.html',
+    })
+    .controller('PortFormCtrl', PortFormCtrl)
+    ;
+
+  /**
+   * @ngInject
+   */
+  function PortFormCtrl(Select, Api) {
+    var portForm = this;
+
+    portForm.$onInit = init;
+    portForm.input = _.clone(INPUTS);
+
+
+    //////////
+
+    function init() {
+      portForm.form.getData = getData;
+      fillFormInputs();
+
+      (portForm.form.on || function () { })(['change', 'load'], storeState);
+
+    }
+
+    function getData(hubId) {
+      var data = _.clone(portForm.input);
+      data.hubId = hubId;
+      return data;
+    }
+
+    function fillFormInputs() {
+      _.overwrite(portForm.input, portForm.form.input);
+    }
+
+    function storeState(response) {
+      fillFormInputs();
+    }
+  }
+})();

--- a/app/network/switch/port/port.form.pug
+++ b/app/network/switch/port/port.form.pug
@@ -1,0 +1,11 @@
+doctype html
+include /resources/angle/pug/mixins/form
+
++field(
+  "{{ 'switch.port.list.modal.form.name.LABEL' | translate }}",
+  "port"
+)(
+  ng-model="portForm.input.name"
+  placeholder="{{ 'switch.port.list.modal.form.name.PLACEHOLDER' | translate }}"
+)
+

--- a/app/network/switch/port/port.list.pug
+++ b/app/network/switch/port/port.list.pug
@@ -2,7 +2,9 @@ list.panel.panel-default(
   ng-if="ports.list"
   list="ports.list"
 )
-  list-header(text="switch.port.list.TITLE")
+  list-header(text="switch.port.list.TITLE") 
+    a.btn.btn-default(ng-click="ports.createPort()")
+      i.fa.fa-plus    
     a.btn.btn-default(ng-click="ports.list.refresh.now()")
       i.fa.fa-refresh
     a.btn.btn-default(ng-click="ports.filters.visible = !ports.filters.visible")

--- a/app/network/switch/port/port.module.js
+++ b/app/network/switch/port/port.module.js
@@ -3,6 +3,7 @@
 
   angular
     .module('app.network.switch.port', [
-      'app.network.switch.port.filters'
+      'app.network.switch.port.filters',
+      'scp.angle.network.switch.port.modal',
     ]);
 })();

--- a/app/network/switch/port/port.table.pug
+++ b/app/network/switch/port/port.table.pug
@@ -1,4 +1,4 @@
-extends /resources/angle/pug/table
+extends /resources/angle/pug/table-checkable
 
 block headings
   th.sortable
@@ -15,7 +15,7 @@ block headings
     sort(col="usage.percent")
   th.sortable
     span(translate="switch.port.list.heading.usage.MAX")
-    sort(col="usage.max")
+    sort(col="usage.max") 
 
 block columns
   td

--- a/resources/assets/lang/en/switch.json
+++ b/resources/assets/lang/en/switch.json
@@ -200,6 +200,27 @@
       },
       "empty": {
         "BODY": "We haven't discovered any ports on this switch yet."
+      },
+      "modal": {
+        "create": {
+          "CANCEL": "Cancel",
+          "CREATE": "Create Port"
+        },
+        "form": {
+          "title": {
+            "ADD": "Create Port"
+          },
+          "name": {
+            "LABEL": "Port",
+            "PLACEHOLDER": "Port Name"
+          }
+        },
+        "delete": {
+          "TITLE": "Delete Switch Ports",
+          "SUBMIT": "Delete",
+          "CANCEL": "Cancel",
+          "BODY": "Click \"Delete\" to permanently delete these Switch Ports:"
+        }
       }
     },
     "filter": {


### PR DESCRIPTION
I've implemented modal-based creation for switch ports. The port scanning is functioning correctly for manually created ports. I've also incorporated bulk deletion and included the test cases mentioned in the ticket.

This PR is related with other 2 PR on: scp-angle and api

![modal](https://github.com/synergycp/scp-theme-admin/assets/26300768/5aafcc2c-1751-45a1-9dd2-8e3739968135)
![BulkDelete](https://github.com/synergycp/scp-theme-admin/assets/26300768/c218be86-1571-47da-90b8-56aeead8dc63)
![BulkDeleteModal](https://github.com/synergycp/scp-theme-admin/assets/26300768/78e8777e-d3e9-4d76-bfce-615e90ebdbee)
