### PR TITLE
On Server edition, It is modified a panel title from Control to Power…

### DIFF
--- a/resources/assets/lang/en/server.json
+++ b/resources/assets/lang/en/server.json
@@ -238,7 +238,7 @@
   },
   "ipmi": {
     "HOSTNAME": "Hostname",
-    "TITLE": "Power Controls",
+    "TITLE": "Controls",
     "NOT_ENABLED": "This server has not been assigned an IPMI IP, username, or password.",
     "web_panel": {
       "HEADING": "Web CP",


### PR DESCRIPTION
It is modified the panel title on the server edition to 'Controls' instead of 'Powers Controls.

After
![admin-after](https://github.com/synergycp/scp-theme-admin/assets/12122895/6f444e44-4bba-4793-b1e3-527f936b0840)
Before
![admin-before](https://github.com/synergycp/scp-theme-admin/assets/12122895/c7cc70ca-7195-4264-aca3-8df22ff92ffd)
